### PR TITLE
Fixes and improvements

### DIFF
--- a/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/arena/Arena.java
+++ b/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/arena/Arena.java
@@ -154,7 +154,7 @@ public class Arena {
 		int column = 0;
 
 		/* Check and add if a new row is needed */
-		if(bubble2DArray.size() < (row+1)) {
+		if(bubble2DArray.size() <= row) {
 			if(bubble2DArray.peekLast() == null || bubble2DArray.peekLast().length != WIDTH_BUBBLES ) {
 				bubble2DArray.add(new Bubble[WIDTH_BUBBLES]);
 			} else {
@@ -323,7 +323,7 @@ public class Arena {
 		int column = 0;
 
 		/* Check and add if a new row is needed */
-		if(bubble2DArray.size() < (row+1)) {
+		if(bubble2DArray.size() <= row) {
 			if(bubble2DArray.peekLast() == null || bubble2DArray.peekLast().length != WIDTH_BUBBLES ) {
 				bubble2DArray.add(new Bubble[WIDTH_BUBBLES]);
 			} else {

--- a/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/arena/Arena.java
+++ b/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/arena/Arena.java
@@ -154,7 +154,7 @@ public class Arena {
 		int column = 0;
 
 		/* Check and add if a new row is needed */
-		if(bubble2DArray.size() <= (row+1)) {
+		if(bubble2DArray.size() < (row+1)) {
 			if(bubble2DArray.peekLast() == null || bubble2DArray.peekLast().length != WIDTH_BUBBLES ) {
 				bubble2DArray.add(new Bubble[WIDTH_BUBBLES]);
 			} else {
@@ -323,7 +323,7 @@ public class Arena {
 		int column = 0;
 
 		/* Check and add if a new row is needed */
-		if(bubble2DArray.size() <= (row+1)) {
+		if(bubble2DArray.size() < (row+1)) {
 			if(bubble2DArray.peekLast() == null || bubble2DArray.peekLast().length != WIDTH_BUBBLES ) {
 				bubble2DArray.add(new Bubble[WIDTH_BUBBLES]);
 			} else {

--- a/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/cannon/Cannon.java
+++ b/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/cannon/Cannon.java
@@ -38,7 +38,6 @@ public class Cannon {
 	private BubbleFactory bubblegen;
 
 	public int TIME_SHOT_FIRED;
-	public int TIMES_SHOT = 0;
 
 	public boolean display_warning;
 
@@ -93,7 +92,6 @@ public class Cannon {
 		this.currBubble.fire(this.ANGLE);
 		this.loadNextBubble();
 		this.TIME_SHOT_FIRED = 0;
-		this.TIMES_SHOT += 1;
 	}
 
 	/**

--- a/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/game/Game.java
+++ b/bust-a-move-framework/src/main/java/nl/tudelft/bust_a_move20162017/bust_a_move_framework/game/Game.java
@@ -148,10 +148,6 @@ public class Game extends BasicGameState {
 			cannon.TIME_SHOT_FIRED = 0;
 			cannon.display_warning = false;
 		}
-		if(cannon.TIMES_SHOT == 10) {
-			cannon.TIMES_SHOT = 0;
-			arena.addBubbleRow();
-		}
 
 		LinkedList<Bubble[]> arenaBubbles = this.arena.get_BubbleArray();
 		for (Bubble b1 : bubbleslist) {
@@ -161,6 +157,7 @@ public class Game extends BasicGameState {
 					b1.hitWall();
 				}
 				// collision with landed bubbles
+				collisionLoop:
 				for (int i = 0; i < arenaBubbles.size(); i++) {
 					for (int j = 0; j < arenaBubbles.get(i).length; j++) {
 						Bubble b2 = arenaBubbles.get(i)[j];
@@ -169,6 +166,7 @@ public class Game extends BasicGameState {
 								if (b1.getBoundingBox().intersects(b2.getBoundingBox())) {
 									System.out.println("Collision! " + b1.getColor() + " with " + b2.getColor());
 									arena.landBubble(b1);
+									break collisionLoop;
 								}
 							}
 						}


### PR DESCRIPTION
Fixes:
creation of unnecessary row at line 157 of Arena.java. This error
occurred when multiple bubbles land on the last row consecutively.

The collision detection now stops when one collision is detected instead
of detecting multiple collision with the same object.

Improvements:
The addBubbleRow after 10 shot is removed from the Game.java since this
is already done inside the landBubble() of Arena.java.
The shot counter is removed from the Cannon class as well. This is not
needed anymore.